### PR TITLE
fix: Unwanted scrollbars are appearing on the links of home page

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -4,7 +4,6 @@
     padding: 0;
     box-sizing: border-box;
     max-width: 100%;
-    overflow-x: hidden;
 }
 
 html, body {


### PR DESCRIPTION
Unwanted scrollbars are appearing on the links of home page

<img width="949" alt="image" src="https://github.com/user-attachments/assets/9daf7926-88c0-45ad-8bc7-0d177b43e9d0" />
